### PR TITLE
Autodetect master nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # elastic-search-monitor
 
 Monitors your elastic search cluster and reports metrics to cloudwatch
+
+## Running locally
+
+* Get a janus token
+* Export the following variables, adapting them for your account (this is for deploy tool)
+
+```bash
+export TagQueryApp="elk-es-master"
+export TagQueryStack="deploy"
+export ClusterName="elk"
+```
+* Then run it by using `sbt run`

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ version := "1.0"
 
 scalaVersion := "2.12.2"
 
+val awsSdkVersion = "1.11.377"
+
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
@@ -19,7 +21,8 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "org.slf4j" % "slf4j-simple" % "1.7.25",
   "com.squareup.okhttp3" % "okhttp" % "3.11.0",
-  "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.369",
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
+  "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7.1",
   "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.7"

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -104,7 +104,7 @@ Resources:
           ClusterName: !Ref ClusterName
       Description: Monitors your elastic search cluster and reports metrics to cloudwatch
       Handler: com.gu.elasticsearchmonitor.Lambda::handler
-      MemorySize: 128
+      MemorySize: 256
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
       Timeout: 60

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -35,13 +35,10 @@ Parameters:
   Subnets:
     Description: Subnets (within your VPC)
     Type: List<AWS::EC2::Subnet::Id>
+  ClusterSecurityGroup:
+    Description: A security group allowing the lambda to connect to port 9200 over TCP
+    Type: AWS::EC2::SecurityGroup::Id
 Resources:
-  LambdaSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Open access to elk cluster
-      VpcId:
-        Ref: VpcId
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -114,16 +111,16 @@ Resources:
       MemorySize: 256
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
-      Timeout: 60
+      Timeout: 180
       VpcConfig:
         SubnetIds: !Ref Subnets
-        SecurityGroupIds: [!GetAtt LambdaSecurityGroup.GroupId]
+        SecurityGroupIds: [ !Ref ClusterSecurityGroup ]
 
   DailyEvent:
     Type: AWS::Events::Rule
     Properties:
       Description: Event sent to process the previous day of data
-      ScheduleExpression: rate(1 minute)
+      ScheduleExpression: rate(3 minutes)
       Targets:
         - Id: Lambda
           Arn: !GetAtt Lambda.Arn

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -16,6 +16,15 @@ Parameters:
       - CODE
       - PROD
     Default: CODE
+  TagQueryApp:
+    Description: Application name of the cluster master node
+    Type: String
+  TagQueryStack:
+    Description: Stack name of the cluster master node
+    Type: String
+  ClusterName:
+    Description: Cluster name to use in the cloudwatch metrics
+    Type: String
   DeployBucket:
     Description: Bucket where RiffRaff uploads artifacts on deploy
     Type: String
@@ -70,6 +79,13 @@ Resources:
                 - ec2:DescribeNetworkInterfaces
                 - ec2:DeleteNetworkInterface
               Resource: "*"
+        - PolicyName: ec2-detection
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - ec2:describeInstances
+              Resource: "*"
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
@@ -83,6 +99,9 @@ Resources:
           Stage: !Ref Stage
           Stack: !Ref Stack
           App: !Ref App
+          TagQueryApp: !Ref TagQueryApp
+          TagQueryStack: !Ref TagQueryStack
+          ClusterName: !Ref ClusterName
       Description: Monitors your elastic search cluster and reports metrics to cloudwatch
       Handler: com.gu.elasticsearchmonitor.Lambda::handler
       MemorySize: 128

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -111,7 +111,7 @@ Resources:
       MemorySize: 256
       Role: !GetAtt ExecutionRole.Arn
       Runtime: java8
-      Timeout: 180
+      Timeout: 60
       VpcConfig:
         SubnetIds: !Ref Subnets
         SecurityGroupIds: [ !Ref ClusterSecurityGroup ]
@@ -120,7 +120,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: Event sent to process the previous day of data
-      ScheduleExpression: rate(3 minutes)
+      ScheduleExpression: rate(1 minute)
       Targets:
         - Id: Lambda
           Arn: !GetAtt Lambda.Arn

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -84,7 +84,14 @@ Resources:
             Statement:
               Effect: Allow
               Action:
-                - ec2:describeInstances
+                - ec2:DescribeInstances
+              Resource: "*"
+        - PolicyName: cloudwatch
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - cloudwatch:PutMetricData
               Resource: "*"
   Lambda:
     Type: AWS::Lambda::Function

--- a/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
@@ -44,7 +44,7 @@ class MasterDetector(amazonEC2: AmazonEC2, httpClient: OkHttpClient) {
 
     Try(queryInstances(Nil, None)) match {
       case Success(instances) =>
-        val instanceNames = instances.map(instance => s"http://${instance.getPrivateDnsName}:9002")
+        val instanceNames = instances.map(instance => s"http://${instance.getPrivateIpAddress}:9002")
         logger.info(s"Identified these instances as potential candidates: $instanceNames")
         val statuses = instanceNames.map(pingInstance)
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
@@ -44,7 +44,7 @@ class MasterDetector(amazonEC2: AmazonEC2, httpClient: OkHttpClient) {
 
     Try(queryInstances(Nil, None)) match {
       case Success(instances) =>
-        val instanceNames = instances.map(instance => s"http://${instance.getPrivateIpAddress}:9002")
+        val instanceNames = instances.map(instance => s"http://${instance.getPrivateIpAddress}:9200")
         logger.info(s"Identified these instances as potential candidates: $instanceNames")
         val statuses = instanceNames.map(pingInstance)
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
@@ -1,0 +1,64 @@
+package com.gu.elasticsearchmonitor
+
+import com.amazonaws.services.ec2.AmazonEC2
+import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter, Instance }
+import okhttp3.{ OkHttpClient, Request }
+import org.slf4j.{ Logger, LoggerFactory }
+
+import collection.JavaConverters._
+import scala.annotation.tailrec
+import scala.util.{ Failure, Random, Success, Try }
+
+class MasterDetector(amazonEC2: AmazonEC2, httpClient: OkHttpClient) {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def detectMasters(env: Env): Either[String, MasterInformation] = {
+    @tailrec
+    def queryInstances(instancesFromPreviousRequest: List[Instance], nextToken: Option[String]): List[Instance] = {
+      val filters = List(
+        new Filter("tag:Stage", List(env.stage).asJava),
+        new Filter("tag:Stack", List(env.tagQueryStack).asJava),
+        new Filter("tag:App", List(env.tagQueryApp).asJava))
+      val dir = new DescribeInstancesRequest().withFilters(filters: _*).withNextToken(nextToken.orNull)
+      val result = amazonEC2.describeInstances(dir)
+      val instances = instancesFromPreviousRequest ++ result.getReservations.asScala.flatMap(_.getInstances.asScala)
+      if (result.getNextToken == null) {
+        instances
+      } else {
+        queryInstances(instances, Option(result.getNextToken))
+      }
+    }
+
+    def pingInstance(instanceName: String): Boolean = {
+      val clusterHealthRequest = new Request.Builder()
+        .url(s"$instanceName/_cluster/health")
+        .build()
+
+      val clusterHealthResponse = Try(httpClient.newCall(clusterHealthRequest).execute())
+      clusterHealthResponse match {
+        case Success(response) if response.code == 200 => true
+        case _ => false
+      }
+    }
+
+    Try(queryInstances(Nil, None)) match {
+      case Success(instances) =>
+        val instanceNames = instances.map(instance => s"http://${instance.getPrivateDnsName}:9002")
+        logger.info(s"Identified these instances as potential candidates: $instanceNames")
+        val statuses = instanceNames.map(pingInstance)
+
+        val aliveInstances = instanceNames.zip(statuses).filter(_._2).map(_._1)
+        val masterInfo = MasterInformation(
+          numberOfMasterInstances = instanceNames.size,
+          numberOfRespondingMasters = aliveInstances.size,
+          aRandomMasterUrl = Random.shuffle(aliveInstances).headOption) //any master should do
+        logger.info(s"Found the following master information: $masterInfo")
+        Right(masterInfo)
+      case Failure(e) =>
+        logger.error("Unable to fetch master instances", e)
+        Left(s"Unable to fetch master instances: ${e.getMessage}")
+    }
+
+  }
+}

--- a/src/main/scala/com/gu/elasticsearchmonitor/MasterInformation.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/MasterInformation.scala
@@ -1,0 +1,6 @@
+package com.gu.elasticsearchmonitor
+
+case class MasterInformation(
+  numberOfMasterInstances: Int,
+  numberOfRespondingMasters: Int,
+  aRandomMasterUrl: Option[String])


### PR DESCRIPTION
Uses EC2 tags to detect master nodes, filter through the one which are offline, then query with one of them (random)