### PR TITLE
Update Data Node alarm threshold

### DIFF
--- a/alarms.yaml
+++ b/alarms.yaml
@@ -48,7 +48,7 @@ Resources:
       Namespace: !Sub ${Stack}/${ClusterName}
       Period: 60
       Statistic: Minimum
-      Threshold: 6
+      Threshold: 3
 
   MasterNodeCountAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## What does this change?

@philmcmahon is experimenting with a new instance type, which allows us to run with 3 Data Nodes. As this is an expected change, I've updated the alarm accordingly.