### PR TITLE
Add cluster status logging

### DIFF
--- a/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
@@ -48,8 +48,6 @@ object ClusterHealth {
             logger.error(s"Failed to obtain debug information about cluster status due to ${requestAttempts.failed.get}")
           }
         }
-        // If status != green
-        // Call GET _cluster/allocation/explain and GET /_nodes(?) and log response
         Right(ClusterHealth(
           clusterName = root.get("cluster_name").asText,
           status = clusterStatus,

--- a/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
@@ -44,8 +44,9 @@ object ClusterHealth {
           } yield {
             logger.warn(s"Cluster is in $clusterStatus. Shard allocation info:\n${shardRequest.body.string}\nNode info:\n${nodeRequest.body.string}")
           }
-          if (requestAttempts.isFailure) {
-            logger.error(s"Failed to obtain debug information about cluster status due to ${requestAttempts.failed.get}")
+          requestAttempts.recover {
+            case exception =>
+              logger.error(s"Failed to obtain debug information about cluster status due to $exception")
           }
         }
         Right(ClusterHealth(

--- a/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
@@ -46,7 +46,7 @@ object ClusterHealth {
           }
           requestAttempts.recover {
             case exception =>
-              logger.error(s"Failed to obtain debug information about cluster status due to $exception")
+              logger.warn(s"Failed to obtain debug information about cluster status due to $exception")
           }
         }
         Right(ClusterHealth(


### PR DESCRIPTION
## What does this change?

This project has been sending alerts fairly regularly due to ELK experiencing [yellow cluster status](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#cluster-health-api-desc), but we're currently unsure _why_ this is happening. This PR makes some additional API calls to Elasticsearch when we encounter this scenario and logs the responses for debugging purposes. The logs for this project are [already in Central ELK](https://logs.gutools.co.uk/s/devx/goto/efae709da6861ee6bd734a17b19d3904), so it should be easy to check what's going on the next time that this happens.

The code isn't especially pretty but hopefully this PR will be fairly short-lived.

## How to test

It's tricky to test this as it relies on a specific cluster status and code with side-effects. I suggest that we monitor this change in production instead.

## How can we measure success?

This should help us to debug the problems that we're experiencing.

## Have we considered potential risks?

These API calls are wrapped in a `Try` so any failures should not interfere with the 'normal' execution of this lambda.