### PR TITLE
Make yellow cluster status alarm less sensitive and add separate alarm for red status

### DIFF
--- a/alarms.yaml
+++ b/alarms.yaml
@@ -77,12 +77,31 @@ Resources:
       Dimensions:
       - Name: Cluster
         Value: !Ref ClusterName
-      EvaluationPeriods: 2
+      EvaluationPeriods: 15
       MetricName: Status
       Namespace: !Sub ${Stack}/${ClusterName}
       Period: 60
       Statistic: Maximum
+      # Green = 0, Yellow = 1, Red = 2
       Threshold: 0
+
+  RedClusterStatusAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !Ref AlertChannel
+      AlarmDescription: !Sub Red cluster status in ${Stage}
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Cluster
+          Value: !Ref ClusterName
+      EvaluationPeriods: 1
+      MetricName: Status
+      Namespace: !Sub ${Stack}/${ClusterName}
+      Period: 60
+      Statistic: Maximum
+      # Green = 0, Yellow = 1, Red = 2
+      Threshold: 1
 
   DataNodeJvmHeapUsageAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## What does this change?

Prior to this PR we had a single alarm which alerted us if the cluster status was not-green (i.e. yellow or red) for 2 minutes.

We regularly experience yellow cluster status for a few minutes, which means that this alarm trips very frequently, despite needing no action.

This PR updates the alarms so that we have a separate, more sensitive alarm for red cluster status (which is much more serious/unusual and is more likely to require intervention). The general purpose alarm has been relaxed so that it will tolerate yellow cluster status for 15 minutes before triggering. This means that in some scenarios we will now receive a duplicate alarm (e.g. if the cluster is red for 15 minutes or more), but I think that's an unusual case so it doesn't worry me too much.

## How to test

This is a PROD-only stack so I have deployed it already in order to test this change. The alarms look correct (to me) in the UI:

![image](https://user-images.githubusercontent.com/19384074/143025600-f326c195-6d31-4562-9a8e-748aed02d092.png)

![image](https://user-images.githubusercontent.com/19384074/143025625-45fcc223-7393-4d7e-bf40-916d90aa352e.png)

## How can we measure success?

We should receive fewer interruptions.

## Have we considered potential risks?

Yes, by making this change we are accepting that the cluster could regularly (albeit briefly) go into yellow status without our knowledge. For the ELK stack specifically, I think that's an acceptable level of risk.
