### PR TITLE
Upgrade to Scala 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.bsp
 *.class
 *.log
 .cache

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description:= "Monitors your elastic search cluster and reports metrics to cloud
 
 version := "1.0"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.13.7"
 
 val awsSdkVersion = "1.11.377"
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,15 +6,14 @@ description:= "Monitors your elastic search cluster and reports metrics to cloud
 
 version := "1.0"
 
-scalaVersion := "2.13.7"
+scalaVersion := "3.1.0"
 
 val awsSdkVersion = "1.11.377"
 
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
-  "-target:jvm-1.8",
-  "-Ywarn-dead-code"
+  "-Xtarget:8"
 )
 
 libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
-
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")

--- a/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
 import org.slf4j.{ Logger, LoggerFactory }
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
@@ -13,11 +13,11 @@ class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def metricDatum(metricName: String, value: Double, unit: StandardUnit, dimensions: List[(String, String)], now: Date): MetricDatum = {
-    val metricDatum = new MetricDatum
+    val metricDatum = MetricDatum()
 
     val cloudwatchDimensions = dimensions.map {
       case (dimensionName, dimensionValue) =>
-        val cloudwatchDimension = new Dimension
+        val cloudwatchDimension = Dimension()
         cloudwatchDimension.setName(dimensionName)
         cloudwatchDimension.setValue(dimensionValue)
         cloudwatchDimension
@@ -31,7 +31,7 @@ class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
   }
 
   def buildMetricData(clusterName: String, clusterHealth: ClusterHealth, nodeStats: NodeStats): List[MetricDatum] = {
-    val now = new Date() // consistent timestamp across metrics
+    val now = Date() // consistent timestamp across metrics
 
     def elasticSearchStatusToDouble(status: String): Double = status match {
       case "green" => 0d
@@ -68,7 +68,7 @@ class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
   }
 
   def buildMasterMetricData(clusterName: String, masterInformation: MasterInformation): List[MetricDatum] = {
-    val now = new Date() // consistent timestamp across metrics
+    val now = Date() // consistent timestamp across metrics
     val defaultDimensions = List("Cluster" -> clusterName)
     List(
       metricDatum("NumberOfMasterNodes", masterInformation.numberOfMasterInstances, StandardUnit.Count, defaultDimensions, now),
@@ -82,7 +82,7 @@ class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
 
     metricBatches.foreach { batch =>
       logger.info(s"Sending a batch of ${batch.size} metrics to cloudwatch")
-      val putMetricDataRequest = new PutMetricDataRequest()
+      val putMetricDataRequest = PutMetricDataRequest()
       putMetricDataRequest.setNamespace(s"${env.stack}/$clusterName")
       putMetricDataRequest.setMetricData(batch.asJava)
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
 import org.slf4j.{ Logger, LoggerFactory }
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 
 class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
@@ -18,15 +18,15 @@ object ClusterHealth {
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def fetchAndParse(host: String, httpClient: OkHttpClient, mapper: ObjectMapper): Either[String, ClusterHealth] = {
-    val clusterHealthRequest = new Request.Builder()
+    val clusterHealthRequest = Request.Builder()
       .url(s"$host/_cluster/health")
       .build()
 
-    val shardAllocationRequest = new Request.Builder()
+    val shardAllocationRequest = Request.Builder()
       .url(s"$host/_cluster/allocation/explain")
       .build()
 
-    val nodeInfoRequest = new Request.Builder()
+    val nodeInfoRequest = Request.Builder()
       .url(s"$host/_nodes")
       .build()
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/ClusterHealth.scala
@@ -58,7 +58,7 @@ object ClusterHealth {
       case Success(response) =>
         Left(s"Unable to fetch the cluster health status. Http code ${response.code}")
 
-      case Failure(NonFatal(e)) =>
+      case Failure(e) =>
         logger.error("Unable to fetch cluster health", e)
         Left(s"Unable to fetch cluster health: ${e.getMessage}")
     }

--- a/src/main/scala/com/gu/elasticsearchmonitor/Lambda.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/Lambda.scala
@@ -44,12 +44,12 @@ object Lambda {
     process(env)
   }
 
-  val httpClient = new OkHttpClient()
+  val httpClient = OkHttpClient()
 
-  val mapper = new ObjectMapper()
+  val mapper = ObjectMapper()
 
-  val credentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("deployTools"),
+  val credentials = AWSCredentialsProviderChain(
+    ProfileCredentialsProvider("deployTools"),
     DefaultAWSCredentialsProviderChain.getInstance)
 
   val cloudwatch: AmazonCloudWatch = AmazonCloudWatchClient.builder()
@@ -62,9 +62,9 @@ object Lambda {
     .withRegion("eu-west-1")
     .build
 
-  val cloudwatchMetrics = new CloudwatchMetrics(Env(), cloudwatch)
+  val cloudwatchMetrics = CloudwatchMetrics(Env(), cloudwatch)
 
-  val masterDetector = new MasterDetector(ec2, httpClient)
+  val masterDetector = MasterDetector(ec2, httpClient)
 
   def process(env: Env): Unit = {
     def resolveMasterHostName(masterInfo: MasterInformation): Either[String, String] =

--- a/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter, Inst
 import okhttp3.{ OkHttpClient, Request }
 import org.slf4j.{ Logger, LoggerFactory }
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.annotation.tailrec
 import scala.util.{ Failure, Random, Success, Try }
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
@@ -17,10 +17,10 @@ class MasterDetector(amazonEC2: AmazonEC2, httpClient: OkHttpClient) {
     @tailrec
     def queryInstances(instancesFromPreviousRequest: List[Instance], nextToken: Option[String]): List[Instance] = {
       val filters = List(
-        new Filter("tag:Stage", List(env.stage).asJava),
-        new Filter("tag:Stack", List(env.tagQueryStack).asJava),
-        new Filter("tag:App", List(env.tagQueryApp).asJava))
-      val dir = new DescribeInstancesRequest().withFilters(filters: _*).withNextToken(nextToken.orNull)
+        Filter("tag:Stage", List(env.stage).asJava),
+        Filter("tag:Stack", List(env.tagQueryStack).asJava),
+        Filter("tag:App", List(env.tagQueryApp).asJava))
+      val dir = DescribeInstancesRequest().withFilters(filters: _*).withNextToken(nextToken.orNull)
       val result = amazonEC2.describeInstances(dir)
       val instances = instancesFromPreviousRequest ++ result.getReservations.asScala.flatMap(_.getInstances.asScala)
       if (result.getNextToken == null) {
@@ -31,7 +31,7 @@ class MasterDetector(amazonEC2: AmazonEC2, httpClient: OkHttpClient) {
     }
 
     def masterRespondsToHealthCheck(instanceName: String): Boolean = {
-      val clusterHealthRequest = new Request.Builder()
+      val clusterHealthRequest = Request.Builder()
         .url(s"$instanceName/_cluster/health")
         .build()
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter, Inst
 import okhttp3.{ OkHttpClient, Request }
 import org.slf4j.{ Logger, LoggerFactory }
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.annotation.tailrec
 import scala.util.{ Failure, Random, Success, Try }
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
@@ -16,7 +16,7 @@ object NodeStats {
   val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def fetchAndParse(host: String, httpClient: OkHttpClient, mapper: ObjectMapper): Either[String, NodeStats] = {
-    val nodeStatsRequest = new Request.Builder()
+    val nodeStatsRequest = Request.Builder()
       .url(s"$host/_nodes/stats")
       .build()
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.{ JsonNode, ObjectMapper }
 import okhttp3.{ OkHttpClient, Request }
 import org.slf4j.{ Logger, LoggerFactory }
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
@@ -30,7 +30,7 @@ object NodeStats {
           nodes = root.get("nodes").iterator().asScala.toList.map(Node.parse)))
       case Success(response) =>
         Left(s"Unable to fetch the node stats. Http code ${response.code}")
-      case Failure(NonFatal(e)) =>
+      case Failure(e) =>
         logger.error("Unable to fetch node stats", e)
         Left(s"Unable to fetch node stats: ${e.getMessage}")
     }

--- a/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.{ JsonNode, ObjectMapper }
 import okhttp3.{ OkHttpClient, Request }
 import org.slf4j.{ Logger, LoggerFactory }
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 


### PR DESCRIPTION
## What does this change?

This PR upgrades the project to use [Scala 3](https://docs.scala-lang.org/scala3/new-in-scala3.html) ([via Scala 2.13!](https://github.com/guardian/elastic-search-monitor/commit/ee283def133e579de21a50c7f4db1e915c8b37bd)). So far I've just fixed warnings and taken advantage of some syntactic sugar:

* [The `new` keyword is now optional for classes as well as case classes](https://docs.scala-lang.org/scala3/reference/other-new-features/creator-applications.html)
* The syntax for [importing](https://docs.scala-lang.org/scala3/book/packaging-imports.html#import-statements-part-1) everything has changed from `_` to `*`

I roughly followed [this migration guide](https://docs.scala-lang.org/scala3/guides/migration/tutorial-sbt.html), but this is a tiny, simple project (without unit tests!), so some of the steps were not relevant. For example, this project only uses Java dependencies so I didn't need to spend any time [preparing the dependencies](https://docs.scala-lang.org/scala3/guides/migration/tutorial-sbt.html#4-prepare-the-dependencies).

## How to test

I'll need to deploy this to `PROD` as there is no `CODE` environment; I will do this next week.

## How can we measure success?

Everything should continue working as before.

In the future we can make use of more interesting Scala 3 features/syntax (as I mentioned above I have only made a few superficial syntax changes in this PR).

## Have we considered potential risks?

I deliberately chose to upgrade this repo because it looked like an easy/low risk place to start experimenting with Scala 3 in production. 