### PR TITLE
Add an alarm to monitor the monitor

### DIFF
--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -92,6 +92,114 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
+    "ScheduledLambdaErrorPercentageAlarmForLambda6F1E8BCD": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":devx-alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "ScheduledLambda68819433",
+              },
+              " exceeded 99% error rate",
+            ],
+          ],
+        },
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "High error % from ",
+              Object {
+                "Ref": "ScheduledLambda68819433",
+              },
+              " lambda in TEST",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 30,
+        "Metrics": Array [
+          Object {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "Error % of ",
+                  Object {
+                    "Ref": "ScheduledLambda68819433",
+                  },
+                ],
+              ],
+            },
+          },
+          Object {
+            "Id": "m1",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "ScheduledLambda68819433",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "m2",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": Object {
+                      "Ref": "ScheduledLambda68819433",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 99,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ScheduledLambdaScheduledLambdarate1minute0064C7EC4": Object {
       "Properties": Object {
         "ScheduleExpression": "rate(1 minute)",

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -53,7 +53,11 @@ export class ElasticSearchMonitor extends GuStack {
       description:
         "Monitors your Elasticsearch cluster and reports metrics to CloudWatch",
       handler: "com.gu.elasticsearchmonitor.Lambda::handler",
-      monitoringConfiguration: { noMonitoring: true },
+      monitoringConfiguration: {
+        toleratedErrorPercentage: 99,
+        numberOfMinutesAboveThresholdBeforeAlarm: 30,
+        snsTopicName: "devx-alerts",
+      },
       rules: [{ schedule: Schedule.rate(Duration.minutes(1)) }],
       runtime: Runtime.JAVA_8,
       // This lambda needs access to the Deploy Tools VPC so that it can talk to Prism


### PR DESCRIPTION
## What does this change?

Whilst migrating to [`@guardian/cdk`](https://github.com/guardian/elastic-search-monitor/pull/17), we [noticed](https://github.com/guardian/elastic-search-monitor/pull/17#discussion_r847116428) that there are no alarms to tell us if we break this application. Consequently this PR adds one (via `@guardian/cdk`'s helpers).

## How to test

I don't think we need to test this, as it's already been tested via `@guardian/cdk`.

## How can we measure success?

We will now be informed if we break this application.

## Have we considered potential risks?

The biggest risk here is a noisy alarm. I've deliberately made the alarm quite tolerant (i.e. we will tolerate the Lambda being completely broken for 30 minutes) to avoid distracting the team unless things are _really broken_.