### PR TITLE
move cdk dependencies to devDependencies

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -27,9 +27,7 @@
     "prettier": "^2.4.1",
     "ts-jest": "^27.0.7",
     "ts-node": "^10.4.0",
-    "typescript": "~4.4.3"
-  },
-  "dependencies": {
+    "typescript": "~4.4.3",
     "@aws-cdk/core": "1.147.0",
     "@aws-cdk/aws-sns-subscriptions": "1.147.0",
     "@aws-cdk/aws-cloudwatch": "1.147.0",


### PR DESCRIPTION
This change moves the cdk dependencies into devDependencies. This brings the configuration into line with the current gucdk setup. Due to the complexity involved, updating to the latest cdk version will be done in a seperate card.