### PR TITLE
Remove redundant riff-raff config

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -18,6 +18,3 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: elastic-search-monitor
       templatePath: ElasticSearchMonitor-PROD.template.json
-      # We should be able to remove the parameters after the initial cdk deployment
-      templateParameters:
-        VpcId: "/account/vpc/primary/id"


### PR DESCRIPTION
## What does this change?

This PR removes some temporary config that was used to [support the migration to GuCDK](https://github.com/guardian/elastic-search-monitor/pull/17). This migration was completed several months ago so this config is no longer needed.

## How to test

There is no `CODE` environment for this service so I have tested this change by [deploying to `PROD`](https://riffraff.gutools.co.uk/deployment/view/62d8614f-4e4d-4058-9881-8224d7a4c0ee?verbose=1). This line shows that parameter values are unchanged despite the removal of this config:

```
[09:12:49] Parameters: DistributionBucketName -> PreviousValue; ClusterSecurityGroup -> PreviousValue; PrivateSubnets -> PreviousValue; VpcId -> PreviousValue
```

## How can we measure success?

We have less YAML in the repo!

## Have we considered potential risks?

I don't think there are any particular risks associated with this PR.