### PR TITLE
Fix deployments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,4 +32,4 @@ assemblyJarName := s"${name.value}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file("cdk/cdk.out/ElasticSearchMonitor-PROD.template.json"), s"${name.value}-cfn/ElasticSearchMonitor-PROD.template.json")
+riffRaffArtifactResources += (file("cdk/cdk.out/ElasticSearchMonitor-PROD.template.json"), s"cdk.out/ElasticSearchMonitor-PROD.template.json")


### PR DESCRIPTION
## What does this change?

There was a [problem deploying](https://riffraff.gutools.co.uk/deployment/view/bb7a3106-336c-4e38-b9fa-6b79034f045b) https://github.com/guardian/elastic-search-monitor/pull/28, where I claimed that:

> I can [preview this change successfully in Riff-Raff](https://riffraff.gutools.co.uk/preview/yaml?project=elastic-search-monitor&build=87&stage=PROD&updateStrategy=MostlyHarmless), which suggests that everything has been uploaded properly. 

Unfortunately this was not true! It would be nice if the preview feature could detect/warn if the file(s) that the deployment needs is not present! 

## How to test

I have [deployed this change and it seems to work](https://riffraff.gutools.co.uk/deployment/view/b3bdbf04-4c59-4e38-b64d-dab91daa8c01).

## How can we measure success?

Deployments work again.