### PR TITLE
Enable Lambda versioning and SnapStart

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
 
 enablePlugins(RiffRaffArtifact)
 
-assemblyJarName := s"${name.value}.jar"
+assemblyJarName := s"${sys.env.getOrElse("BUILD_NUMBER", "DEV")}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -6,6 +6,7 @@ const app = new GuRootExperimental();
 new ElasticSearchMonitor(app, "ElasticSearchMonitor-PROD", {
   stack: "deploy",
   stage: "PROD",
+  buildNumber: process.env.BUILD_NUMBER ?? "DEV",
   env: {
     region: "eu-west-1",
   },

--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -377,6 +377,9 @@ Object {
           ],
         },
         "Runtime": "java11",
+        "SnapStart": Object {
+          "ApplyOn": "PublishedVersions",
+        },
         "Tags": Array [
           Object {
             "Key": "App",
@@ -420,7 +423,7 @@ Object {
         },
         "FunctionVersion": Object {
           "Fn::GetAtt": Array [
-            "ScheduledLambdaCurrentVersionC4FAB78107a726524e749e4cf54a82c3739c64c9",
+            "ScheduledLambdaCurrentVersionC4FAB781dac5e6c9d5f2062b110dd13d3974cd2b",
             "Version",
           ],
         },
@@ -428,7 +431,7 @@ Object {
       },
       "Type": "AWS::Lambda::Alias",
     },
-    "ScheduledLambdaCurrentVersionC4FAB78107a726524e749e4cf54a82c3739c64c9": Object {
+    "ScheduledLambdaCurrentVersionC4FAB781dac5e6c9d5f2062b110dd13d3974cd2b": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "ScheduledLambda68819433",

--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -413,6 +413,29 @@ Object {
       },
       "Type": "AWS::Lambda::Function",
     },
+    "ScheduledLambdaAliasForLambda8D5BCFFF": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "ScheduledLambda68819433",
+        },
+        "FunctionVersion": Object {
+          "Fn::GetAtt": Array [
+            "ScheduledLambdaCurrentVersionC4FAB78107a726524e749e4cf54a82c3739c64c9",
+            "Version",
+          ],
+        },
+        "Name": "TEST",
+      },
+      "Type": "AWS::Lambda::Alias",
+    },
+    "ScheduledLambdaCurrentVersionC4FAB78107a726524e749e4cf54a82c3739c64c9": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "ScheduledLambda68819433",
+        },
+      },
+      "Type": "AWS::Lambda::Version",
+    },
     "ScheduledLambdaErrorPercentageAlarmForLambda6F1E8BCD": Object {
       "Properties": Object {
         "ActionsEnabled": true,
@@ -528,10 +551,7 @@ Object {
         "Targets": Array [
           Object {
             "Arn": Object {
-              "Fn::GetAtt": Array [
-                "ScheduledLambda68819433",
-                "Arn",
-              ],
+              "Ref": "ScheduledLambdaAliasForLambda8D5BCFFF",
             },
             "Id": "Target0",
           },
@@ -539,14 +559,11 @@ Object {
       },
       "Type": "AWS::Events::Rule",
     },
-    "ScheduledLambdaScheduledLambdarate1minute0AllowEventRuleElasticSearchMonitorScheduledLambdaDFD7F6B32CFE3E7A": Object {
+    "ScheduledLambdaScheduledLambdarate1minute0AllowEventRuleElasticSearchMonitorScheduledLambdaAliasForLambda3B0095D95F72C854": Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
-          "Fn::GetAtt": Array [
-            "ScheduledLambda68819433",
-            "Arn",
-          ],
+          "Ref": "ScheduledLambdaAliasForLambda8D5BCFFF",
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": Object {

--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -355,7 +355,7 @@ Object {
           "S3Bucket": Object {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "deploy/TEST/elastic-search-monitor/elastic-search-monitor.jar",
+          "S3Key": "deploy/TEST/elastic-search-monitor/DEV.jar",
         },
         "Description": "Monitors your Elasticsearch cluster and reports metrics to CloudWatch",
         "Environment": Object {
@@ -662,7 +662,7 @@ Object {
                       Object {
                         "Ref": "DistributionBucketName",
                       },
-                      "/deploy/TEST/elastic-search-monitor/elastic-search-monitor.jar",
+                      "/deploy/TEST/elastic-search-monitor/DEV.jar",
                     ],
                   ],
                 },

--- a/cdk/lib/elastic-search-monitor.test.ts
+++ b/cdk/lib/elastic-search-monitor.test.ts
@@ -8,6 +8,7 @@ describe("The ElasticSearchMonitor stack", () => {
     const stack = new ElasticSearchMonitor(app, "ElasticSearchMonitor", {
       stack: "deploy",
       stage: "TEST",
+      buildNumber: "DEV",
     });
     expect(Template.fromStack(stack)).toMatchSnapshot();
   });

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -55,6 +55,7 @@ export class ElasticSearchMonitor extends GuStack {
     const scheduledLambda = new GuScheduledLambda(this, "ScheduledLambda", {
       app,
       fileName: `${props.buildNumber}.jar`,
+      enableVersioning: true,
       environment: {
         TAG_QUERY_APP: "elk-es-master",
         TAG_QUERY_STACK: "deploy",

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -15,8 +15,12 @@ import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
 
 const app = "elastic-search-monitor";
 
+export interface ElasticSearchMonitorProps extends GuStackProps {
+  buildNumber: string;
+}
+
 export class ElasticSearchMonitor extends GuStack {
-  constructor(scope: App, id: string, props: GuStackProps) {
+  constructor(scope: App, id: string, props: ElasticSearchMonitorProps) {
     super(scope, id, props);
     const clusterSecurityGroupId = new CfnParameter(
       this,
@@ -50,7 +54,7 @@ export class ElasticSearchMonitor extends GuStack {
     ];
     const scheduledLambda = new GuScheduledLambda(this, "ScheduledLambda", {
       app,
-      fileName: "elastic-search-monitor.jar",
+      fileName: `${props.buildNumber}.jar`,
       environment: {
         TAG_QUERY_APP: "elk-es-master",
         TAG_QUERY_STACK: "deploy",

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -9,6 +9,7 @@ import { ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import { Schedule } from "aws-cdk-lib/aws-events";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
+import type { CfnFunction } from "aws-cdk-lib/aws-lambda";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
@@ -84,6 +85,10 @@ export class ElasticSearchMonitor extends GuStack {
         ),
       ],
     });
+
+    const cfnLambda = scheduledLambda.node.defaultChild as CfnFunction;
+    cfnLambda.snapStart = { applyOn: "PublishedVersions" };
+
     additionalPolicies.map((policy) => scheduledLambda.addToRolePolicy(policy));
 
     const topicForElasticsearchAlerts = new Topic(this, "ElkAlertChannel", {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -29,7 +29,7 @@
     "ts-jest": "^27.0.7",
     "ts-node": "^10.4.0",
     "typescript": "~4.4.3",
-    "@guardian/cdk": "49.1.0",
+    "@guardian/cdk": "50.0.0-beta.1",
     "source-map-support": "^0.5.20"
   }
 }

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -347,16 +347,16 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/cdk@49.1.0":
-  version "49.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-49.1.0.tgz#e9a9209416066ccb3016a824fe09adcd13c313bd"
-  integrity sha512-2QKzixZxBx7c53ITpXG3hHZVoUqu+awd7PGZtx132MtrjV5hEN3G7sLtICdezMLxXPbIcagHRfk8yasu1Zi7bA==
+"@guardian/cdk@50.0.0-beta.1":
+  version "50.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@guardian/cdk/-/cdk-50.0.0-beta.1.tgz#396114eb5282dbbd743d2baf1e77a27e64ccf17a"
+  integrity sha512-2gSYq2muLR8Eklqk8aJvqwtd4JqhjedcnbpanDsk3EIOEwH/SBbD0Zx4sToDGQplm18UcCCekbPcbB1IcxPgBg==
   dependencies:
     "@oclif/core" "1.24.2"
     aws-cdk-lib "2.59.0"
-    aws-sdk "^2.1296.0"
+    aws-sdk "^2.1306.0"
     chalk "^4.1.2"
-    codemaker "^1.73.0"
+    codemaker "^1.74.0"
     constructs "10.1.215"
     git-url-parse "^13.1.0"
     js-yaml "^4.1.0"
@@ -1100,10 +1100,10 @@ aws-cdk@2.59.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-aws-sdk@^2.1296.0:
-  version "2.1303.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1303.0.tgz#c339c515a7b419bb9c081c5da6731f18c738793e"
-  integrity sha512-KTzMliy60ParQgmnHB3jcAZVQmyLV1ZlNK4jUDP6Hzb0SPZFkGHzzjfSb224o8pB/HfR5n4fT3hOUVWMjISwdA==
+aws-sdk@^2.1306.0:
+  version "2.1312.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1312.0.tgz#5b52ba9cef0984b0d86a1755a79b11c3ec775797"
+  integrity sha512-NG6ERxxxU6p+CDWrq7wLinp0siKRcCNN98iY0qr/2WKZbz5JCtDyiQV/l+6jLmNKP5qIT5z++jnDy9cgNP6ICQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1363,10 +1363,10 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
-codemaker@^1.73.0:
-  version "1.73.0"
-  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.73.0.tgz#5b3b280759a31ee259bbcdc50ba9bd46e115b787"
-  integrity sha512-pgVFCAbR0Yw/qTrV/W8R7cXWJouhONMRf8sNCjmAGJyV3MFaLN4sUPdUkzYUu7LCkuHPh0nvYRlExWzrkhm7vw==
+codemaker@^1.74.0:
+  version "1.74.0"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.74.0.tgz#113d679c5f2d6bc6bb04621448930e48cf8cec40"
+  integrity sha512-i6fAyWpXAYN/dd8hvzFPJ7+Yb/a23+BmeCu/lPn0KDpDs/KpNKoz/I3Iq9JD4AL9bMc1b7kBeBV+UF6kS6EMEg==
   dependencies:
     camelcase "^6.3.0"
     decamelize "^5.0.1"


### PR DESCRIPTION
## What does this change?

This PR enables Lambda versioning and [SnapStart](https://docs.google.com/document/d/1ZC9o70gfWoEgfmbd4C0w87SUYqzbMx5CID38EOqf8dA/edit#heading=h.dowx40pffo62). It relies on some GuCDK changes: https://github.com/guardian/cdk/pull/1721. 

This is just a proof of concept to demonstrate how we can start using SnapStart at the Guardian with our existing tooling; there is no particular reason that we need to improve the performance of this Lambda.

### Technical details

Previously, the event rule would invoke the latest unpublished version of this Lambda function (`$LATEST`). It now triggers the latest published version of the function, via an alias.

In order to ensure that we publish a new Lambda version for every build, we now include the build number in the `fileName` for this Lambda, rather than reusing a generic name each time.

As we now publish a new Lambda version by uploading a new `.jar` and forcing the Lambda to update via CloudFormation, there is no need to make an API call to update the function code associated with `$LATEST` as part of every deployment. Consequently the `riff-raff.yaml` file that is generated for this project is also simplified to avoid this unnecessary API call.

Here is a [diff of the changes to the auto-generated riff-raff.yaml](https://github.com/guardian/elastic-search-monitor/pull/32/files); there is no snapshot for this (perhaps there should be?!).

## How to test

I have deployed this change to test it out.

### Versioning

These [logs](https://logs.gutools.co.uk/s/devx/goto/200b16d0-a932-11ed-950f-71c06fbbf814) show that we are now using a Lambda version instead of `$LATEST`.

Before: `START RequestId: cf2bdbd9-03dd-4836-b33f-e15c4b87cfad Version: $LATEST`

After: `START RequestId: 986d36b1-44c6-482b-8719-25a54073f0a8 Version: 1`

### SnapStart

These [logs](https://logs.gutools.co.uk/s/devx/goto/7dbd19f0-a931-11ed-972a-75e6441e29d6) show that we are now using SnapStart.

We can see this because we now have `Restore Duration: 437.46 ms` instead of `Init Duration: 461.84 ms` (the performance gain in this particular case is very small, but the aim of this PR is just to prove that SnapStart can be used with Riff-Raff so that we can try it out for some services which actually need the performance benefits!).

## How can we measure success?

We can use the SnapStart feature and have demonstrated its compatibility with Riff-Raff.

## Have we considered potential risks?

Yes, this is a new feature (and a new deployment approach) so it's possible that we will discover problems with it. This project is pretty low risk (and is not user facing), so this seems like a good place to experiment with this approach.

There are a couple of things to be aware of at this stage:

### Configuration updates and rollback

AWS CDK is automatically updating the logical id of the Lambda version whenever it detects that the Lambda will be updated. This means that whenever we deploy a _different build number_ from the previously deployed build number a new Lambda version will be created and the old Lambda version will be deleted. This has a couple of important implications:

1. Rollbacks work the same as our current projects[^1]. Consider the following sequence:

| Time | Action | Behaviour |
| ----- | -----| ----- |
| 10:00 | Use Riff-Raff to deploy build 1 | All requests will be handled by Lambda version 1 |
| 10:05 | Use Riff-Raff to deploy build 2 | All requests will be handled by Lambda version 2 (Lambda version 1 will be deleted automatically) |
| 10:10 | Use Riff-Raff to redeploy build 1 due to a bug with build 2 | All requests will be handled by Lambda version 3 (Lambda version 2 will be deleted automatically) |

2. If configuration is loaded as part of Lambda initialisation[^2] it **will not** be refreshed by redeploying the build number that was previously deployed. Consider the following scenario:

| Time | Action | Behaviour |
| ----- | -----| ----- |
| 10:00 | Use Riff-Raff to deploy build 1 | All requests will be handled by Lambda version 1 (with a snapshot of the config from 10:00) |
| 10:05 | Update config manually via parameter store in the AWS console | All requests will be handled by Lambda version 1 (with a snapshot of the config from 10:00) |
| 10:10 | Redeploy build 1 in an attempt to force the Lambda to reload config | All requests will be handled by Lambda version 1 (with a snapshot of the config from 10:00) |

When using `$LATEST` (i.e. when not using Lambda versions) the deployment at 10:10 would force AWS Lambda to reload config[^3]. When using Lambda versions, the new config would not be loaded and the service would continue using a snapshot of the config _from 10:00_.

This is because there would be no change to the logical id of the Lambda version and therefore (from CloudFormation's perspective) no need to provision a new Lambda version. In order to force the new config to load, you would need to change the build number (this could be achieved pretty simply by running a new CI build for the `main` branch). Alternatively we could [reference the config version in application code](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-versions.html) and update it explicitly when config changes are made. This has some other benefits[^4] despite the additional overhead.

### Storage usage

Every time we deploy a project with Riff-Raff, we upload a `.jar` file to an S3 bucket. Prior to this change we used the same name every time we uploaded the `.jar`. We have versioning enabled but we use lifecycle rules to delete old/unused versions after 60 days[^5], which stops storage usage from increasing too much over time. 

We now upload a `.jar` with a unique name every time we deploy a build with Riff-Raff, which means that these lifecycle rules will not automatically tidy up old builds. We might want to consider a naming convention/lifecycle rule to tidy up old builds automatically. I don't actually think we need the `.jar` file in S3 once the Lambda version has been published, so we could force these objects to expire pretty quickly.

[^1]: However, they are a little slower, as the rollback now requires a CloudFormation update to provision the new Lambda version
[^2]: It is common to load config outside of the handler function so that AWS can cache it and improve performance.
[^3]: IIUC this is because AWS provisions new containers for your new Lambda (i.e. the updated `$LATEST` unpublished version), which means that you get coldstarts (and potentially a significant performance hit) as well as the config change.
[^4]: It would give us a better audit trail of config changes and would prevent configuration changes from being rolled out accidentally, as a side effect.
[^5]: I'm not sure if this is the case across the organisation (I am just basing this on the Deploy Tools account).