### PR TITLE
Mention what the metric value means in the ClusterStatusAlarm's descriptions

### DIFF
--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -67,7 +67,7 @@ Object {
             ],
           },
         ],
-        "AlarmDescription": "Unexpected cluster status in TEST",
+        "AlarmDescription": "Unexpected cluster status in TEST. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
           Object {
@@ -328,7 +328,7 @@ Object {
             ],
           },
         ],
-        "AlarmDescription": "Red cluster status in TEST",
+        "AlarmDescription": "Red cluster status in TEST. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
           Object {

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -138,7 +138,7 @@ export class ElasticSearchMonitor extends GuStack {
 
     new GuAlarm(this, "ClusterStatusAlarm", {
       ...greaterThanAlarmProps,
-      alarmDescription: `Unexpected cluster status in ${this.stage}`,
+      alarmDescription: `Unexpected cluster status in ${this.stage}. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)`,
       evaluationPeriods: 15,
       metric: metric("Status"),
       // Green = 0, Yellow = 1, Red = 2
@@ -147,7 +147,7 @@ export class ElasticSearchMonitor extends GuStack {
 
     new GuAlarm(this, "RedClusterStatusAlarm", {
       ...greaterThanAlarmProps,
-      alarmDescription: `Red cluster status in ${this.stage}`,
+      alarmDescription: `Red cluster status in ${this.stage}. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)`,
       evaluationPeriods: 1,
       metric: metric("Status"),
       // Green = 0, Yellow = 1, Red = 2


### PR DESCRIPTION
## What does this change?

This updates the description of the alarm so it mentions what the meaning is of the metric being at 0, 1 and 2. 

## How to test

It's a string change so I think it's pretty low risk, but it should update the description [in this page](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/elastic-search-monitor-PROD-ClusterStatusAlarm75657749-1EQJZAKPQHWYT?) once it ships.

## Have we considered potential risks?

If not done correctly, this change could break the alarm.

## Images
![Screenshot 2023-02-28 at 10 46 53](https://user-images.githubusercontent.com/1672034/221832069-d42d688d-11b8-4e9a-a495-9789d5989a04.png)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
