### PR TITLE
bump jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,7 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "3.11.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.6.7",
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.7.1",
-  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.6.7"
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
 )
 
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,13 @@ libraryDependencies ++= Seq(
 
 enablePlugins(RiffRaffArtifact)
 
+assembly / assemblyMergeStrategy := {
+  case x if x.endsWith("module-info.class") => MergeStrategy.first
+  case y =>
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
+    oldStrategy(y)
+}
+
 assemblyJarName := s"${name.value}.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Bumps jackson databind to resolve vulnerabilities
core and annotations have been removed as they are brought in transitively by databind
