### PR TITLE
remove redundant app variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ jobs:
     - name: Upload to riff-raff
       uses: guardian/actions-riff-raff@v2
       with:
-        app: elastic-search-monitor
         configPath: cdk/cdk.out/riff-raff.yaml
         projectName: elastic-search-monitor
         buildNumberOffset: 99


### PR DESCRIPTION
## What does this change?

Removes a redundant app variable from riff riff actions, similar to a recent PR on deploy-tools-platform repo
