### PR TITLE
chore(deps): Remove unused `sbt-riffraff-artifact` plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,6 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
 )
 
-enablePlugins(RiffRaffArtifact)
-
 assembly / assemblyMergeStrategy := {
   case x if x.endsWith("module-info.class") => MergeStrategy.first
   case y =>
@@ -34,7 +32,3 @@ assembly / assemblyMergeStrategy := {
 }
 
 assemblyJarName := s"${name.value}.jar"
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffArtifactResources += (file("cdk/cdk.out/ElasticSearchMonitor-PROD.template.json"), s"cdk.out/ElasticSearchMonitor-PROD.template.json")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.8")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")


### PR DESCRIPTION
## What does this change?
Since #37 we are using https://github.com/guardian/actions-riff-raff to upload CI artifacts to Riff-Raff, so the SBT plugin can be removed.

## How to test
CI should continue to work, with the build of this branch visible in Riff-Raff.