### PR TITLE
Tolerate yellow cluster status for longer before sending an alert

### DIFF
--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -75,7 +75,7 @@ Object {
             "Value": "elk",
           },
         ],
-        "EvaluationPeriods": 15,
+        "EvaluationPeriods": 30,
         "MetricName": "Status",
         "Namespace": "deploy/elk",
         "Period": 60,

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -139,7 +139,7 @@ export class ElasticSearchMonitor extends GuStack {
     new GuAlarm(this, "ClusterStatusAlarm", {
       ...greaterThanAlarmProps,
       alarmDescription: `Unexpected cluster status in ${this.stage}. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)`,
-      evaluationPeriods: 15,
+      evaluationPeriods: 30, // Tolerate yellow status for 30 mins before sending an alert
       metric: metric("Status"),
       // Green = 0, Yellow = 1, Red = 2
       threshold: 0,


### PR DESCRIPTION
Follow-up to https://github.com/guardian/elastic-search-monitor/pull/8.

We have received a notification for this alarm a few times recently. It seems pretty common for the cluster status to be yellow for ~20 minutes before automatically resolving (i.e. it becomes green again without any developers taking an action). This now happens frequently enough that developers (including me!) often ignore the email.

We seem to have tacitly accepted the risk of the cluster status being yellow for longer than 15 minutes[^1], so this PR makes that risk acceptance explicit. This helps to reduce noise and increases the likelihood that we'll respond to more meaningful alarm notifications in the future.

[^1]: There is no user impact associated with yellow status; it just means that we've lost redundancy (i.e. we might lose data if we lose another data node).