### PR TITLE
Add runbook link to cloudwatch alarms

### DIFF
--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -67,7 +67,7 @@ Object {
             ],
           },
         ],
-        "AlarmDescription": "Unexpected cluster status in TEST. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)",
+        "AlarmDescription": "Unexpected cluster status in TEST. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2). Runbook: https://docs.google.com/document/d/1PuEvL7L-CTV72Jx4OmiB3y5hlMmJR7Xz-YxYWAMiGdY",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
           Object {
@@ -111,7 +111,7 @@ Object {
             ],
           },
         ],
-        "AlarmDescription": "Unexpected count of data nodes in TEST",
+        "AlarmDescription": "Unexpected count of data nodes in TEST. Runbook: https://docs.google.com/document/d/1PuEvL7L-CTV72Jx4OmiB3y5hlMmJR7Xz-YxYWAMiGdY",
         "ComparisonOperator": "LessThanThreshold",
         "Dimensions": Array [
           Object {
@@ -284,7 +284,7 @@ Object {
             ],
           },
         ],
-        "AlarmDescription": "Unexpected count of master nodes in TEST",
+        "AlarmDescription": "Unexpected count of master nodes in TEST. Runbook: https://docs.google.com/document/d/1PuEvL7L-CTV72Jx4OmiB3y5hlMmJR7Xz-YxYWAMiGdY",
         "ComparisonOperator": "LessThanThreshold",
         "Dimensions": Array [
           Object {
@@ -328,7 +328,7 @@ Object {
             ],
           },
         ],
-        "AlarmDescription": "Red cluster status in TEST. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)",
+        "AlarmDescription": "Red cluster status in TEST. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2). Runbook: https://docs.google.com/document/d/1PuEvL7L-CTV72Jx4OmiB3y5hlMmJR7Xz-YxYWAMiGdY",
         "ComparisonOperator": "GreaterThanThreshold",
         "Dimensions": Array [
           Object {

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -122,7 +122,7 @@ export class ElasticSearchMonitor extends GuStack {
 
     new GuAlarm(this, "DataNodeCountAlarm", {
       ...lessThanAlarmProps,
-      alarmDescription: `Unexpected count of data nodes in ${this.stage}`,
+      alarmDescription: `Unexpected count of data nodes in ${this.stage}. Runbook: https://docs.google.com/document/d/1PuEvL7L-CTV72Jx4OmiB3y5hlMmJR7Xz-YxYWAMiGdY`,
       evaluationPeriods: 2,
       metric: metric("NumberOfDataNodes"),
       threshold: 3,
@@ -130,7 +130,7 @@ export class ElasticSearchMonitor extends GuStack {
 
     new GuAlarm(this, "MasterNodeCountAlarm", {
       ...lessThanAlarmProps,
-      alarmDescription: `Unexpected count of master nodes in ${this.stage}`,
+      alarmDescription: `Unexpected count of master nodes in ${this.stage}. Runbook: https://docs.google.com/document/d/1PuEvL7L-CTV72Jx4OmiB3y5hlMmJR7Xz-YxYWAMiGdY`,
       evaluationPeriods: 2,
       metric: metric("NumberOfRespondingMastersNodes"),
       threshold: 3,
@@ -138,7 +138,7 @@ export class ElasticSearchMonitor extends GuStack {
 
     new GuAlarm(this, "ClusterStatusAlarm", {
       ...greaterThanAlarmProps,
-      alarmDescription: `Unexpected cluster status in ${this.stage}. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)`,
+      alarmDescription: `Unexpected cluster status in ${this.stage}. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2). Runbook: https://docs.google.com/document/d/1PuEvL7L-CTV72Jx4OmiB3y5hlMmJR7Xz-YxYWAMiGdY`,
       evaluationPeriods: 30, // Tolerate yellow status for 30 mins before sending an alert
       metric: metric("Status"),
       // Green = 0, Yellow = 1, Red = 2
@@ -147,7 +147,7 @@ export class ElasticSearchMonitor extends GuStack {
 
     new GuAlarm(this, "RedClusterStatusAlarm", {
       ...greaterThanAlarmProps,
-      alarmDescription: `Red cluster status in ${this.stage}. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2)`,
+      alarmDescription: `Red cluster status in ${this.stage}. See cloudwatch metric value for current cluster status (Green = 0, Yellow = 1, Red = 2). Runbook: https://docs.google.com/document/d/1PuEvL7L-CTV72Jx4OmiB3y5hlMmJR7Xz-YxYWAMiGdY`,
       evaluationPeriods: 1,
       metric: metric("Status"),
       // Green = 0, Yellow = 1, Red = 2


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This adds a link to devx elk runbook to each alarm description. The description is included in the email notification we get, so it should lower the barrier of entry for the developer investigating the alert.
