### PR TITLE
Reconfigure storage metrics/alarms to use available disk space

### DIFF
--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -214,7 +214,7 @@ Object {
           },
         ],
         "EvaluationPeriods": 2,
-        "MetricName": "MinFreeDiskSpace",
+        "MetricName": "MinAvailableDiskSpace",
         "Namespace": "deploy/elk",
         "Period": 60,
         "Statistic": "Minimum",

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -176,7 +176,7 @@ export class ElasticSearchMonitor extends GuStack {
       ...lessThanAlarmProps,
       alarmDescription: lowStorageDescription,
       evaluationPeriods: 2,
-      metric: metric("MinFreeDiskSpace"),
+      metric: metric("MinAvailableDiskSpace"),
       threshold: fifteenPercentDiskSpaceInBytes,
     });
   }

--- a/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
@@ -46,19 +46,19 @@ class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
     val nodeMetrics = nodeStats.nodes.flatMap { node =>
       val dimensions = defaultDimensions ++ List("InstanceId" -> node.name)
       List(
-        metricDatum("FreeDiskSpace", node.dataFree.toDouble, StandardUnit.Bytes, dimensions, now),
+        metricDatum("AvailableDiskSpace", node.dataAvailable.toDouble, StandardUnit.Bytes, dimensions, now),
         metricDatum("TotalDiskSpace", node.dataTotal.toDouble, StandardUnit.Bytes, dimensions, now),
         metricDatum("JvmHeapUsage", node.jvmHeapUsedPercent.toDouble, StandardUnit.Percent, dimensions, now))
     }
     val dataNodes = nodeStats.nodes.filter(_.isDataNode)
     val aggregatedDataNodeMetrics = if (dataNodes.nonEmpty) {
-      val minFreeDiskSpace = dataNodes.minBy(_.dataFree).dataFree
-      val sumFreeDiskSpace = dataNodes.map(_.dataFree).sum
+      val minAvailableDiskSpace = dataNodes.minBy(_.dataAvailable).dataAvailable
+      val sumAvailableDiskSpace = dataNodes.map(_.dataAvailable).sum
       val sumTotalDiskSpace = dataNodes.map(_.dataTotal).sum
       val maxJvmHeapUsage = dataNodes.maxBy(_.jvmHeapUsedPercent).jvmHeapUsedPercent
       List(
-        metricDatum("MinFreeDiskSpace", minFreeDiskSpace.toDouble, StandardUnit.Bytes, defaultDimensions, now),
-        metricDatum("SumFreeDiskSpace", sumFreeDiskSpace.toDouble, StandardUnit.Bytes, defaultDimensions, now),
+        metricDatum("MinAvailableDiskSpace", minAvailableDiskSpace.toDouble, StandardUnit.Bytes, defaultDimensions, now),
+        metricDatum("SumAvailableDiskSpace", sumAvailableDiskSpace.toDouble, StandardUnit.Bytes, defaultDimensions, now),
         metricDatum("SumTotalDiskSpace", sumTotalDiskSpace.toDouble, StandardUnit.Bytes, defaultDimensions, now),
         metricDatum("MaxJvmHeapUsage", maxJvmHeapUsage.toDouble, StandardUnit.Bytes, defaultDimensions, now))
     } else Nil

--- a/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/NodeStats.scala
@@ -41,7 +41,7 @@ object NodeStats {
 
 case class Node(
   name: String,
-  dataFree: Long,
+  dataAvailable: Long,
   dataTotal: Long,
   jvmHeapUsedPercent: Int,
   isDataNode: Boolean)
@@ -50,7 +50,7 @@ object Node {
   def parse(jsonNode: JsonNode): Node = {
     Node(
       name = jsonNode.get("name").asText,
-      dataFree = jsonNode.get("fs").get("total").get("free_in_bytes").asLong,
+      dataAvailable = jsonNode.get("fs").get("total").get("available_in_bytes").asLong,
       dataTotal = jsonNode.get("fs").get("total").get("total_in_bytes").asLong,
       jvmHeapUsedPercent = jsonNode.get("jvm").get("mem").get("heap_used_percent").asInt,
       isDataNode = jsonNode.get("roles").elements().asScala.toList.map(_.asText).contains("data"))


### PR DESCRIPTION
## What does this change?

We've recently had some problems with nodes running out of disk space (see https://github.com/guardian/deploy-tools-platform/pull/754 for more details). Despite this, we haven't been receiving alarms related to disk space. I believe this is because we are using a different property to Elasticsearch/Cerebro to evaluate disk usage.

https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html

Currently we use:

> **free_in_bytes**
> (integer) Total number of unallocated bytes in all file stores.

This PR updates the code to use:

> **available_in_bytes**
> (integer) Total number of bytes available to this Java virtual machine on all file stores. Depending on OS or process level restrictions (e.g. XFS quotas), this might appear less than free_in_bytes. **This is the actual amount of free disk space the Elasticsearch node can utilise.**

I think that last sentence (emphasis mine), suggests that `available_in_bytes` is the more useful metric to monitor.

## How to test

This service only has a `PROD` environment, so I will double check that all of the metrics look correct after merging.

## How can we measure success?

We should get a more timely alarm if nodes are running out of disk space.

## Have we considered potential risks?

We will stop pushing new data points for the `MinFreeDiskSpace` and `SumFreeDiskSpace` metrics. I'm pretty sure that the alarm (also reconfigured in this PR) is the only thing looking at these metrics, but there is a small risk that I've forgotten something!