### PR TITLE
Use 20% threshold for low disk space alarm

### DIFF
--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -218,7 +218,7 @@ Object {
         "Namespace": "deploy/elk",
         "Period": 60,
         "Statistic": "Minimum",
-        "Threshold": 991759488253,
+        "Threshold": 1000083134874,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -218,7 +218,7 @@ Object {
         "Namespace": "deploy/elk",
         "Period": 60,
         "Statistic": "Minimum",
-        "Threshold": 743819616190,
+        "Threshold": 991759488253,
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -170,14 +170,14 @@ export class ElasticSearchMonitor extends GuStack {
     Double check the disk space used (curl -s 'localhost:9200/_cat/allocation?v') and access the logs to see if you can
     find any useful error messages ($ grep "ERROR" /var/log/syslog).`;
 
-    const fifteenPercentDiskSpaceInBytes = 743819616190;
+    const twentyPercentDiskSpaceInBytes = 991759488253;
 
     new GuAlarm(this, "DataNodeLowStorageAlarm", {
       ...lessThanAlarmProps,
       alarmDescription: lowStorageDescription,
       evaluationPeriods: 2,
       metric: metric("MinAvailableDiskSpace"),
-      threshold: fifteenPercentDiskSpaceInBytes,
+      threshold: twentyPercentDiskSpaceInBytes,
     });
   }
 }

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -4,7 +4,7 @@ import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuVpc } from "@guardian/cdk/lib/constructs/ec2";
 import type { App } from "aws-cdk-lib";
-import { CfnParameter, Duration } from "aws-cdk-lib";
+import { CfnParameter, Duration, Size } from "aws-cdk-lib";
 import { ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
 import { SecurityGroup } from "aws-cdk-lib/aws-ec2";
 import { Schedule } from "aws-cdk-lib/aws-events";
@@ -170,7 +170,11 @@ export class ElasticSearchMonitor extends GuStack {
     Double check the disk space used (curl -s 'localhost:9200/_cat/allocation?v') and access the logs to see if you can
     find any useful error messages ($ grep "ERROR" /var/log/syslog).`;
 
-    const twentyPercentDiskSpaceInBytes = 991759488253;
+    // See: https://aws.amazon.com/ec2/instance-types/i3en/ and https://www.google.com/search?q=5000gb+in+gib&oq=5000gb+in+gib
+    const totalStorage = Size.gibibytes(4657);
+    const twentyPercentDiskSpaceInBytes = Math.round(
+      totalStorage.toBytes() * 0.2
+    );
 
     new GuAlarm(this, "DataNodeLowStorageAlarm", {
       ...lessThanAlarmProps,


### PR DESCRIPTION
We have recently learnt that a data node hitting 85% disk usage causes stability problems for the cluster (see https://github.com/guardian/deploy-tools-platform/pull/754 and https://github.com/guardian/elastic-search-monitor/pull/103). 

Consequently, this PR updates the alarm threshold so that we get a warning about storage usage before we reach the problematic 85% threshold. This should help us to address these types of problems before we start seeing yellow cluster status due to storage constraints.