### PR TITLE
Migrate to AWS Java SDK v2 (second attempt)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ version := "1.0"
 
 scalaVersion := "3.3.6"
 
-val awsSdkVersion = "1.12.792"
+val awsSdkVersion = "2.35.0"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -18,8 +18,8 @@ scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.4.0",
   "com.squareup.okhttp3" % "okhttp" % "4.12.0",
-  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
-  "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+  "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion,
+  "software.amazon.awssdk" % "ec2" % awsSdkVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.19.1",
 )
 

--- a/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/CloudwatchMetrics.scala
@@ -1,35 +1,36 @@
 package com.gu.elasticsearchmonitor
 
 import java.util.Date
-import com.amazonaws.services.cloudwatch.AmazonCloudWatch
-import com.amazonaws.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import com.amazonaws.services.lambda.runtime.logging.LogLevel
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
 
+import java.time.Instant
 import scala.jdk.CollectionConverters.*
 
-class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
+class CloudwatchMetrics(env: Env, cloudWatch: CloudWatchClient) {
 
-  def metricDatum(metricName: String, value: Double, unit: StandardUnit, dimensions: List[(String, String)], now: Date): MetricDatum = {
-    val metricDatum = MetricDatum()
-
+  def metricDatum(metricName: String, value: Double, unit: StandardUnit, dimensions: List[(String, String)], now: Instant): MetricDatum = {
     val cloudwatchDimensions = dimensions.map {
       case (dimensionName, dimensionValue) =>
-        val cloudwatchDimension = Dimension()
-        cloudwatchDimension.setName(dimensionName)
-        cloudwatchDimension.setValue(dimensionValue)
-        cloudwatchDimension
+        Dimension
+          .builder()
+          .name(dimensionName)
+          .value(dimensionValue)
+          .build()
     }
-    metricDatum.setDimensions(cloudwatchDimensions.asJava)
-    metricDatum.setMetricName(metricName)
-    metricDatum.setValue(value)
-    metricDatum.setUnit(unit)
-    metricDatum.setTimestamp(now)
-    metricDatum
+    MetricDatum.builder()
+      .dimensions(cloudwatchDimensions.asJava)
+      .metricName(metricName)
+      .value(value)
+      .unit(unit)
+      .timestamp(now)
+      .build()
   }
 
   def buildMetricData(clusterName: String, clusterHealth: ClusterHealth, nodeStats: NodeStats): List[MetricDatum] = {
-    val now = Date() // consistent timestamp across metrics
+    val now = Date().toInstant // consistent timestamp across metrics
 
     def elasticSearchStatusToDouble(status: String): Double = status match {
       case "green" => 0d
@@ -40,15 +41,15 @@ class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
     val defaultDimensions = List("Cluster" -> clusterName)
 
     val clusterMetrics = List(
-      metricDatum("NumberOfNodes", clusterHealth.numberOfNodes.toDouble, StandardUnit.Count, defaultDimensions, now),
-      metricDatum("NumberOfDataNodes", clusterHealth.numberOfDataNodes.toDouble, StandardUnit.Count, defaultDimensions, now),
-      metricDatum("Status", elasticSearchStatusToDouble(clusterHealth.status), StandardUnit.None, defaultDimensions, now))
+      metricDatum("NumberOfNodes", clusterHealth.numberOfNodes.toDouble, StandardUnit.COUNT, defaultDimensions, now),
+      metricDatum("NumberOfDataNodes", clusterHealth.numberOfDataNodes.toDouble, StandardUnit.COUNT, defaultDimensions, now),
+      metricDatum("Status", elasticSearchStatusToDouble(clusterHealth.status), StandardUnit.NONE, defaultDimensions, now))
     val nodeMetrics = nodeStats.nodes.flatMap { node =>
       val dimensions = defaultDimensions ++ List("InstanceId" -> node.name)
       List(
-        metricDatum("AvailableDiskSpace", node.dataAvailable.toDouble, StandardUnit.Bytes, dimensions, now),
-        metricDatum("TotalDiskSpace", node.dataTotal.toDouble, StandardUnit.Bytes, dimensions, now),
-        metricDatum("JvmHeapUsage", node.jvmHeapUsedPercent.toDouble, StandardUnit.Percent, dimensions, now))
+        metricDatum("AvailableDiskSpace", node.dataAvailable.toDouble, StandardUnit.BYTES, dimensions, now),
+        metricDatum("TotalDiskSpace", node.dataTotal.toDouble, StandardUnit.BYTES, dimensions, now),
+        metricDatum("JvmHeapUsage", node.jvmHeapUsedPercent.toDouble, StandardUnit.PERCENT, dimensions, now))
     }
     val dataNodes = nodeStats.nodes.filter(_.isDataNode)
     val aggregatedDataNodeMetrics = if (dataNodes.nonEmpty) {
@@ -57,20 +58,20 @@ class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
       val sumTotalDiskSpace = dataNodes.map(_.dataTotal).sum
       val maxJvmHeapUsage = dataNodes.maxBy(_.jvmHeapUsedPercent).jvmHeapUsedPercent
       List(
-        metricDatum("MinAvailableDiskSpace", minAvailableDiskSpace.toDouble, StandardUnit.Bytes, defaultDimensions, now),
-        metricDatum("SumAvailableDiskSpace", sumAvailableDiskSpace.toDouble, StandardUnit.Bytes, defaultDimensions, now),
-        metricDatum("SumTotalDiskSpace", sumTotalDiskSpace.toDouble, StandardUnit.Bytes, defaultDimensions, now),
-        metricDatum("MaxJvmHeapUsage", maxJvmHeapUsage.toDouble, StandardUnit.Bytes, defaultDimensions, now))
+        metricDatum("MinAvailableDiskSpace", minAvailableDiskSpace.toDouble, StandardUnit.BYTES, defaultDimensions, now),
+        metricDatum("SumAvailableDiskSpace", sumAvailableDiskSpace.toDouble, StandardUnit.BYTES, defaultDimensions, now),
+        metricDatum("SumTotalDiskSpace", sumTotalDiskSpace.toDouble, StandardUnit.BYTES, defaultDimensions, now),
+        metricDatum("MaxJvmHeapUsage", maxJvmHeapUsage.toDouble, StandardUnit.PERCENT, defaultDimensions, now))
     } else Nil
     clusterMetrics ++ nodeMetrics ++ aggregatedDataNodeMetrics
   }
 
   def buildMasterMetricData(clusterName: String, masterInformation: MasterInformation): List[MetricDatum] = {
-    val now = Date() // consistent timestamp across metrics
+    val now = Date().toInstant // consistent timestamp across metrics
     val defaultDimensions = List("Cluster" -> clusterName)
     List(
-      metricDatum("NumberOfMasterNodes", masterInformation.numberOfMasterInstances, StandardUnit.Count, defaultDimensions, now),
-      metricDatum("NumberOfRespondingMastersNodes", masterInformation.numberOfRespondingMasters, StandardUnit.Count, defaultDimensions, now))
+      metricDatum("NumberOfMasterNodes", masterInformation.numberOfMasterInstances, StandardUnit.COUNT, defaultDimensions, now),
+      metricDatum("NumberOfRespondingMastersNodes", masterInformation.numberOfRespondingMasters, StandardUnit.COUNT, defaultDimensions, now))
   }
 
   def sendMetrics(clusterName: String, metrics: List[MetricDatum], logger: LambdaLogger): Unit = {
@@ -80,9 +81,11 @@ class CloudwatchMetrics(env: Env, cloudWatch: AmazonCloudWatch) {
 
     metricBatches.foreach { batch =>
       logger.log(s"Sending a batch of ${batch.size} metrics to cloudwatch", LogLevel.INFO)
-      val putMetricDataRequest = PutMetricDataRequest()
-      putMetricDataRequest.setNamespace(s"${env.stack}/$clusterName")
-      putMetricDataRequest.setMetricData(batch.asJava)
+      val putMetricDataRequest = PutMetricDataRequest
+        .builder()
+        .namespace(s"${env.stack}/$clusterName")
+        .metricData(batch.asJava)
+        .build()
 
       cloudWatch.putMetricData(putMetricDataRequest)
     }

--- a/src/main/scala/com/gu/elasticsearchmonitor/Lambda.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/Lambda.scala
@@ -1,13 +1,13 @@
 package com.gu.elasticsearchmonitor
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
-import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClient}
-import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2Client}
 import com.amazonaws.services.lambda.runtime.logging.LogLevel
 import com.amazonaws.services.lambda.runtime.{Context, LambdaLogger}
 import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.OkHttpClient
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.ec2.Ec2Client
 
 import scala.util.{Failure, Success, Try}
 
@@ -46,19 +46,19 @@ object Lambda {
   val httpClient = OkHttpClient()
 
   val mapper = ObjectMapper()
+  
+  val credentials = DefaultCredentialsProvider.builder
+    .profileName("deployTools")
+    .build()
 
-  val credentials = AWSCredentialsProviderChain(
-    ProfileCredentialsProvider("deployTools"),
-    DefaultAWSCredentialsProviderChain.getInstance)
-
-  val cloudwatch: AmazonCloudWatch = AmazonCloudWatchClient.builder()
-    .withCredentials(credentials)
-    .withRegion("eu-west-1")
+  val cloudwatch: CloudWatchClient = CloudWatchClient.builder()
+    .credentialsProvider(credentials)
+    .region(Region.EU_WEST_1)
     .build
 
-  val ec2: AmazonEC2 = AmazonEC2Client.builder()
-    .withCredentials(credentials)
-    .withRegion("eu-west-1")
+  val ec2: Ec2Client = Ec2Client.builder()
+    .credentialsProvider(credentials)
+    .region(Region.EU_WEST_1)
     .build
 
   val cloudwatchMetrics = CloudwatchMetrics(Env(), cloudwatch)

--- a/src/main/scala/com/gu/elasticsearchmonitor/Lambda.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/Lambda.scala
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.{Context, LambdaLogger}
 import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.OkHttpClient
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.http.apache.ApacheHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
 import software.amazon.awssdk.services.ec2.Ec2Client
@@ -54,11 +55,13 @@ object Lambda {
   val cloudwatch: CloudWatchClient = CloudWatchClient.builder()
     .credentialsProvider(credentials)
     .region(Region.EU_WEST_1)
+    .httpClientBuilder(ApacheHttpClient.builder())
     .build
 
   val ec2: Ec2Client = Ec2Client.builder()
     .credentialsProvider(credentials)
     .region(Region.EU_WEST_1)
+    .httpClientBuilder(ApacheHttpClient.builder())
     .build
 
   val cloudwatchMetrics = CloudwatchMetrics(Env(), cloudwatch)

--- a/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
+++ b/src/main/scala/com/gu/elasticsearchmonitor/MasterDetector.scala
@@ -1,32 +1,27 @@
 package com.gu.elasticsearchmonitor
 
-import com.amazonaws.services.ec2.AmazonEC2
-import com.amazonaws.services.ec2.model.{ DescribeInstancesRequest, Filter, Instance }
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import com.amazonaws.services.lambda.runtime.logging.LogLevel
 import okhttp3.{ OkHttpClient, Request }
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.{ DescribeInstancesRequest, Filter, Instance }
 
 import scala.jdk.CollectionConverters.*
-import scala.annotation.tailrec
 import scala.util.{ Failure, Random, Success, Try }
 
-class MasterDetector(amazonEC2: AmazonEC2, httpClient: OkHttpClient) {
+class MasterDetector(amazonEC2: Ec2Client, httpClient: OkHttpClient) {
 
   def detectMasters(env: Env, logger: LambdaLogger): Either[String, MasterInformation] = {
-    @tailrec
     def queryInstances(instancesFromPreviousRequest: List[Instance], nextToken: Option[String]): List[Instance] = {
       val filters = List(
-        Filter("tag:Stage", List(env.stage).asJava),
-        Filter("tag:Stack", List(env.tagQueryStack).asJava),
-        Filter("tag:App", List(env.tagQueryApp).asJava))
-      val dir = DescribeInstancesRequest().withFilters(filters: _*).withNextToken(nextToken.orNull)
-      val result = amazonEC2.describeInstances(dir)
-      val instances = instancesFromPreviousRequest ++ result.getReservations.asScala.flatMap(_.getInstances.asScala)
-      if (result.getNextToken == null) {
-        instances
-      } else {
-        queryInstances(instances, Option(result.getNextToken))
-      }
+        Filter.builder().name("tag:Stage").values(List(env.stage).asJava).build(),
+        Filter.builder().name("tag:Stack").values(List(env.tagQueryStack).asJava).build(),
+        Filter.builder().name("tag:App").values(List(env.tagQueryApp).asJava).build())
+      val instancesRequest = DescribeInstancesRequest.builder()
+        .filters(filters.asJava)
+        .build()
+      val paginator = amazonEC2.describeInstancesPaginator(instancesRequest)
+      paginator.asScala.toList.flatMap(_.reservations.asScala.toList.flatMap(_.instances.asScala))
     }
 
     def masterRespondsToHealthCheck(instanceName: String): Boolean = {
@@ -45,7 +40,7 @@ class MasterDetector(amazonEC2: AmazonEC2, httpClient: OkHttpClient) {
 
     Try(queryInstances(Nil, None)) match {
       case Success(instances) =>
-        val instanceNames = instances.map(instance => s"http://${instance.getPrivateIpAddress}:9200")
+        val instanceNames = instances.map(instance => s"http://${instance.privateIpAddress}:9200")
         logger.log(s"Identified these instances as potential candidates: $instanceNames", LogLevel.INFO)
         val aliveInstances = instanceNames.filter(masterRespondsToHealthCheck)
 


### PR DESCRIPTION
This is a second attempt at https://github.com/guardian/elastic-search-monitor/pull/252.

The first attempt to upgrade worked locally but failed when running in AWS Lambda with a `java.lang.ExceptionInInitializerError`:

`Caused by: software.amazon.awssdk.core.exception.SdkClientException: Unable to load an HTTP implementation from any provider in the chain. You must declare a dependency on an appropriate HTTP implementation or pass in an SdkHttpClient explicitly to the client builder`

The problem seems to be caused by our `sbt assembly` [merge strategy](https://github.com/guardian/elastic-search-monitor/blob/4f131fe5f28b3b2ff60c90f590f9c26ccfe893f6/build.sbt#L27) discarding code that is required at runtime (see [related issue](https://github.com/aws/aws-sdk-java-v2/issues/446)).

There are a couple of suggested fixes for this - changing the merge strategy or explicitly specifying the HTTP client that should be used - I've opted for the latter here https://github.com/guardian/elastic-search-monitor/commit/d1e79a74b19e694b9cf2a94a10c887cf8b158932 as I can see that this approach was taken by other projects at the Guardian (for example https://github.com/guardian/ophan-housekeeper/pull/256).

Due to the problems with the previous attempt at this I briefly [deployed this branch to `PROD`](https://riffraff.gutools.co.uk/deployment/view/1e4e185a-e67b-426b-a44d-7d39aa284c1e) to confirm that it now [runs as expected](https://logs.gutools.co.uk/s/devx/app/r/s/LXFRV):

<img width="1659" height="458" alt="image" src="https://github.com/user-attachments/assets/c082dcfa-7af9-467d-b50a-b9b592e0503e" />