### PR TITLE
Bump AWS SDK to 2.42.26 to fix Netty CVEs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ version := "1.0"
 
 scalaVersion := "3.3.7"
 
-val awsSdkVersion = "2.41.34"
+val awsSdkVersion = "2.42.26"
 
 scalacOptions ++= Seq(
   "-deprecation",


### PR DESCRIPTION
## What does this change?

Bumps aws sdk to latest version to fix GHSA-pwqr-wmgm-9rr8 and GHSA-w9fj-cfpg-grvv.