### PR TITLE
Update alarm topic

### DIFF
--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -56,13 +56,7 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "ElkAlertChannel1915A337",
-                    "TopicName",
-                  ],
-                },
+                ":devx-reliabilityandoperations",
               ],
             ],
           },
@@ -118,13 +112,7 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "ElkAlertChannel1915A337",
-                    "TopicName",
-                  ],
-                },
+                ":devx-reliabilityandoperations",
               ],
             ],
           },
@@ -180,13 +168,7 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "ElkAlertChannel1915A337",
-                    "TopicName",
-                  ],
-                },
+                ":devx-reliabilityandoperations",
               ],
             ],
           },
@@ -242,13 +224,7 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "ElkAlertChannel1915A337",
-                    "TopicName",
-                  ],
-                },
+                ":devx-reliabilityandoperations",
               ],
             ],
           },
@@ -290,41 +266,6 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ElkAlertChannel1915A337": {
-      "Properties": {
-        "DisplayName": "ELK alert channel for TEST",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/elastic-search-monitor",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "TopicName": "elk-alerts-TEST",
-      },
-      "Type": "AWS::SNS::Topic",
-    },
-    "ElkAlertChanneldevxsecopsguardiancouk276AF53D": {
-      "Properties": {
-        "Endpoint": "devx.sec.ops@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "ElkAlertChannel1915A337",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
     "MasterNodeCountAlarmFE01B272": {
       "Properties": {
         "ActionsEnabled": true,
@@ -341,13 +282,7 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "ElkAlertChannel1915A337",
-                    "TopicName",
-                  ],
-                },
+                ":devx-reliabilityandoperations",
               ],
             ],
           },
@@ -403,13 +338,7 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "ElkAlertChannel1915A337",
-                    "TopicName",
-                  ],
-                },
+                ":devx-reliabilityandoperations",
               ],
             ],
           },
@@ -536,7 +465,7 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":devx-alerts",
+                ":devx-reliabilityandoperations",
               ],
             ],
           },

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -10,8 +10,6 @@ import { SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import { Topic } from 'aws-cdk-lib/aws-sns';
-import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 
 const app = 'elastic-search-monitor';
 
@@ -62,7 +60,7 @@ export class ElasticSearchMonitor extends GuStack {
 			monitoringConfiguration: {
 				toleratedErrorPercentage: 99,
 				numberOfEvaluationPeriodsAboveThresholdBeforeAlarm: 30,
-				snsTopicName: 'devx-alerts',
+				snsTopicName: 'devx-reliabilityandoperations',
 			},
 			rules: [{ schedule: Schedule.rate(Duration.minutes(1)) }],
 			runtime: Runtime.JAVA_21,
@@ -81,15 +79,6 @@ export class ElasticSearchMonitor extends GuStack {
 		});
 		additionalPolicies.map((policy) => scheduledLambda.addToRolePolicy(policy));
 
-		const topicForElasticsearchAlerts = new Topic(this, 'ElkAlertChannel', {
-			displayName: `ELK alert channel for ${this.stage}`,
-			topicName: `elk-alerts-${this.stage}`,
-		});
-
-		topicForElasticsearchAlerts.addSubscription(
-			new EmailSubscription('devx.sec.ops@guardian.co.uk'),
-		);
-
 		const clusterName = 'elk';
 
 		const metric = (metricName: string) => {
@@ -104,7 +93,7 @@ export class ElasticSearchMonitor extends GuStack {
 
 		const commonAlarmProps = {
 			app,
-			snsTopicName: topicForElasticsearchAlerts.topicName,
+			snsTopicName: 'devx-reliabilityandoperations',
 			period: Duration.minutes(1),
 		};
 


### PR DESCRIPTION
@JuliaBrigitte and I noticed that these alarm notifications are being sent to colleagues who do not maintain the ELK stack.

This PR updates the SNS topic used so that these notifications are sent to @guardian/devx-reliability-and-ops only going forwards.

Note that this will need to be deployed dangerously as it's removing an SNS topic.