### PR TITLE
fix: Configure `OKActions` for JVM alarm

### DIFF
--- a/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
+++ b/cdk/lib/__snapshots__/elastic-search-monitor.test.ts.snap
@@ -184,6 +184,24 @@ exports[`The ElasticSearchMonitor stack matches the snapshot 1`] = `
         "EvaluationPeriods": 2,
         "MetricName": "MaxJvmHeapUsage",
         "Namespace": "deploy/elk",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":devx-reliabilityandoperations",
+              ],
+            ],
+          },
+        ],
         "Period": 60,
         "Statistic": "Maximum",
         "Tags": [

--- a/cdk/lib/elastic-search-monitor.ts
+++ b/cdk/lib/elastic-search-monitor.ts
@@ -149,6 +149,7 @@ export class ElasticSearchMonitor extends GuStack {
 			evaluationPeriods: 2,
 			metric: metric('MaxJvmHeapUsage'),
 			threshold: 85,
+			okAction: true,
 		});
 
 		const lowStorageDescription = `A data node is running out of disk space.


### PR DESCRIPTION
## What does this change?
The `MaxJvmHeapUsage` alarm fired over the weekend:

<img width="946" height="875" alt="image" src="https://github.com/user-attachments/assets/f224e234-f9c4-442d-90eb-3d8f15a7ff75" />

Looking in CloudWatch metrics, it looks to have resolved by itself pretty qiuckly:

<img width="1286" height="447" alt="image" src="https://github.com/user-attachments/assets/a60e1ee9-459d-4ea4-ba85-5729a3e1ec21" />

This change configures the alarm's [OKActions](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-cloudwatch-alarm.html#cfn-cloudwatch-alarm-okactions) so that we receive a notification for this status change. This can change the amount of investigation performed.